### PR TITLE
Eliminate strongtyping dependency

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
-== 1.6.0 - ???
+== 1.6.0 - 16-Jan-2019
 * Changed license to Apache 2.0.
 * Removed strongtyping dependency, now comes bundled with a pure Ruby
   version instead.
+* Minor documentation updates.
 
 == 1.5.2 - 4-Nov-2018
 * Added metadata to gemspec.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+== 1.6.0 - ???
+* Changed license to Apache 2.0.
+* Removed strongtyping dependency, now comes bundled with a pure Ruby
+  version instead.
+
 == 1.5.2 - 4-Nov-2018
 * Added metadata to gemspec.
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -28,6 +28,7 @@ doc/examples/simple2.rb
 doc/examples/simple3.rb
 
 lib/html-table.rb
+lib/strongtyping.rb
 lib/html/attribute_handler.rb
 lib/html/body.rb
 lib/html/caption.rb

--- a/README
+++ b/README
@@ -2,7 +2,6 @@
   An interface for generating HTML Tables with Ruby.
 
 == Prerequisites
-  * strongtyping 2.0.6 or later
   * structured_warnings 0.3.0 or later
 
 == Installation
@@ -97,7 +96,7 @@
   Holden Glova and Culley Harrelson for API suggestions and comments.
 
 == License
-  Artistic 2.0
+  Apache 2.0
 
 == Copyright
   (C) 2003-2018 Daniel J. Berger
@@ -112,8 +111,8 @@
   Daniel J. Berger
 
 == Developer's Notes
-  Some people might be a little annoyed with the fact that I required Ryan
-  Pavlik's strongtyping library. I'm not a big fan of strong typing myself.
+  Some people might be a little annoyed with the fact that I use a
+  strongtyping library. I'm not a big fan of strong typing myself.
   So, why did I do this?
 
   Normally when creating code, you setup your own rules as far as what is
@@ -124,9 +123,13 @@
   that you don't need the strong typing training wheels after all, right?
 
   However, HTML tables have a predefined set of rules as far as what content
-  is valid, and where it's placed in order to be HTML 4.0 compliant. For
+  is valid, and where it's placed in order to be HTML compliant. For
   example, if a caption is included, it should be at the 'top' of your table
   syntax, you can only have one foot section, and so on. I therefore chose to
-  enforce these conventions and rules in Ruby via Ryan's module. I could have
-  lived without it, and instead chose to do a plethora of "kind_of?" checks.
-  However, Ryan's package is both faster and required less typing on my part.
+  enforce these conventions and rules in Ruby via a module. I could have
+  lived without it, and instead chose to do a plethora of "kind_of?" checks,
+  but the strongtyping lib is simply more convenient all around.
+
+  UPDATE: I originally used Ryan Pavlik's strongtyping library as a dependency.
+  As of version 1.6.0 I now simply include a pure Ruby version with this library.
+  This makes it easier to work with JRuby and eliminates a dependency.

--- a/README
+++ b/README
@@ -96,10 +96,10 @@
   Holden Glova and Culley Harrelson for API suggestions and comments.
 
 == License
-  Apache 2.0
+  Apache-2.0
 
 == Copyright
-  (C) 2003-2018 Daniel J. Berger
+  (C) 2003-2019 Daniel J. Berger
   All Rights Reserved
 
 == Warranty

--- a/doc/table.rdoc
+++ b/doc/table.rdoc
@@ -141,10 +141,10 @@ Table#unshift(obj)
    Holden Glova and Culley Harrelson for API suggestions and comments.
 
 == License
-   Ruby's
+   Apache-2.0
 
 == Copyright
-   (C) 2003-2008 Daniel J. Berger
+   (C) 2003-2019 Daniel J. Berger
    All Rights Reserved
 
 == Warranty
@@ -154,5 +154,3 @@ Table#unshift(obj)
 
 == Author
    Daniel J. Berger
-   djberg96 at nospam at gmail dot com
-   imperator on IRC (irc.freenode.net)

--- a/html-table.gemspec
+++ b/html-table.gemspec
@@ -2,9 +2,9 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'html-table'
-  spec.version    = '1.5.2'
+  spec.version    = '1.6.0'
   spec.author     = 'Daniel J. Berger'
-  spec.license    = 'Artistic 2.0'
+  spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'http://github.com/djberg96/html-table'
   spec.summary    = 'A Ruby interface for generating HTML tables'
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.extra_rdoc_files  = ['README', 'CHANGES'] + Dir['doc/*.rdoc']
 
-  spec.add_dependency('strongtyping')
   spec.add_dependency('structured_warnings', '~> 0.3.0')
 
   spec.add_development_dependency('test-unit')

--- a/lib/html/table.rb
+++ b/lib/html/table.rb
@@ -20,7 +20,7 @@ module HTML
     include HtmlHandler
 
     # The version of the html-table library
-    VERSION = '1.5.2'.freeze
+    VERSION = '1.6.0'.freeze
 
     # The indentation level for the <table> and </table> tags
     @indent_level = 0

--- a/lib/strongtyping.rb
+++ b/lib/strongtyping.rb
@@ -1,0 +1,13 @@
+# A pure-ruby replacement for strongtyping gem
+
+module StrongTyping
+  class ArgumentTypeError < ArgumentError; end
+
+  def expect(arg, allowed_types)
+    return true if Array(allowed_types).any? do |klass|
+      arg.kind_of?(klass)
+    end
+
+    raise ArgumentTypeError.new("#{arg} must be of type #{allowed_types}")
+  end
+end

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -16,7 +16,7 @@ class TC_HTML_Table < Test::Unit::TestCase
   end
 
   def test_version
-    assert_equal('1.5.2', Table::VERSION)
+    assert_equal('1.6.0', Table::VERSION)
     assert_true(Table::VERSION.frozen?)
   end
 


### PR DESCRIPTION
This PR replaces the strongtyping dependency with a bundled, pure Ruby replacement instead.