### PR TITLE
Fix warning around width with percent sign, update tests

### DIFF
--- a/lib/html/mixin/attribute_handler.rb
+++ b/lib/html/mixin/attribute_handler.rb
@@ -2,7 +2,7 @@
 # with HTML tables.  In some cases validation is done on the setters.
 #--
 # The seemingly redundant writer methods were left here for backwards
-# compatibility and for those who may not prefer the DSI.
+# compatibility and for those who may not prefer the DSL.
 #
 module HTML
   module Mixin
@@ -394,7 +394,7 @@ module HTML
       end
 
       def width=(num)
-        if num =~ /%/
+        if num.to_s =~ /%/
           @width = num
         else
           raise ArgumentError if num.to_i < 0

--- a/test/test_attribute_handler.rb
+++ b/test/test_attribute_handler.rb
@@ -344,7 +344,11 @@ class TC_AttributeHandler < Test::Unit::TestCase
       assert_respond_to(@table, :width=)
       assert_nothing_raised{ @table.width}
       assert_nothing_raised{ @table.width = 10 }
+   end
+
+   def test_width_with_percent
       assert_nothing_raised{ @table.width = '5%' }
+      assert_equal('5%', @table.width)
    end
 
    def test_width_expected_errors


### PR DESCRIPTION
This fixes a `deprecated Object#=~ is called on Integer; it always returns nil` warning that appeared when handling percent signs on the width attribute.

This fixes it by adding an explicit `.to_s` call on the value first. I also updated the tests a bit and fixed a typo.