### PR TITLE
Call super instead of redundant instance_eval

### DIFF
--- a/lib/html/body.rb
+++ b/lib/html/body.rb
@@ -13,10 +13,10 @@ module HTML
     def initialize(arg = nil, &block)
       @html_begin = '<tbody'
       @html_end   = '</tbody>'
-      instance_eval(&block) if block_given?
+      super(&block)
       self.content = arg if arg
     end
-      
+
     # Returns a boolean indicating whether or not end tags, </tbody>, are
     # included for each Body object in the final HTML output.  The
     # default is true.
@@ -24,7 +24,7 @@ module HTML
     def self.end_tags?
       @end_tags
     end
-      
+
     # Sets whether or not end tags are included for each Body object in
     # the final HTML output.  The default is true.  Only true or false are
     # valid arguments.

--- a/lib/html/colgroup.rb
+++ b/lib/html/colgroup.rb
@@ -19,7 +19,7 @@ module HTML
       @html_begin = '<colgroup'
       @html_body  = ''
       @html_end   = '</colgroup>'
-      instance_eval(&block) if block_given?
+      super(&block)
       push(arg) if arg
     end
 

--- a/lib/html/foot.rb
+++ b/lib/html/foot.rb
@@ -11,23 +11,23 @@ module HTML
     @end_tags     = true
 
     # This is our constructor for Foot objects because it is a singleton
-    # class.  Optionally, a block may be provided.  If an argument is 
+    # class. Optionally, a block may be provided. If an argument is
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
       @@foot = new(arg, &block) unless @@foot
       @@foot
-    end      
-     
-    # Called by create() instead of new().  This initializes the Foot class.
+    end
+
+    # Called by create() instead of new(). This initializes the Foot class.
     #
     def initialize(arg, &block)
       @html_begin = '<tfoot'
       @html_end   = '</tfoot>'
-      instance_eval(&block) if block_given?
+      super(&block)
       self.content = arg if arg
     end
-     
+
     # Returns a boolean indicating whether or not end tags, </tfoot>, are
     # included for each Foot object in the final HTML output.  The
     # default is true.
@@ -35,7 +35,7 @@ module HTML
     def self.end_tags?
       @end_tags
     end
-     
+
     # Sets whether or not end tags are included for each Foot object in
     # the final HTML output.  The default is true.  Only true or false are
     # valid arguments.

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -1,5 +1,5 @@
 module HTML
-   
+
   # This class represents an HTML table head (<thead>).  It is a
   # subclass of Table::TableSection.  It is a singleton class.
   #
@@ -12,23 +12,23 @@ module HTML
     @end_tags     = true
 
     # This is our constructor for Head objects because it is a singleton
-    # class.  Optionally, a block may be provided.  If an argument is 
+    # class.  Optionally, a block may be provided.  If an argument is
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
       @@head = new(arg, &block) unless @@head
       @@head
-    end      
+    end
 
     # Called by create() instead of new().  This initializes the Head class.
     #
     def initialize(arg, &block)
       @html_begin = '<thead'
       @html_end   = '</thead>'
-      instance_eval(&block) if block_given?
+      super(&block)
       self.content = arg if arg
     end
-     
+
     # Returns a boolean indicating whether or not end tags, </thead>, are
     # included for each Head object in the final HTML output.  The
     # default is true.
@@ -36,7 +36,7 @@ module HTML
     def self.end_tags?
       @end_tags
     end
-     
+
     # Sets whether or not end tags are included for each Head object in
     # the final HTML output.  The default is true.  Only true or false are
     # valid arguments.


### PR DESCRIPTION
Call `super(&block)` where possible for subclasses.