### PR TITLE
Test and fix uppercase handling

### DIFF
--- a/lib/html/mixin/html_handler.rb
+++ b/lib/html/mixin/html_handler.rb
@@ -2,7 +2,7 @@ module HTML
   module Mixin
     module HtmlHandler
 
-      $upper = false
+      $html_table_uppercase = false
 
       # Used on HTML attributes. It creates proper HTML text based on the argument
       # type.  A string looks like "attr='text'", a number looks like "attr=1",
@@ -40,13 +40,13 @@ module HTML
       def html(formatting = true)
         if self.class.respond_to?(:html_case)
           if self.class.html_case == 'upper'
-            $upper = true
+            $html_table_uppercase = true
           else
-            $upper = false
+            $html_table_uppercase = false
           end
         end
 
-        if $upper
+        if $html_table_uppercase
           @html_begin.upcase!
           @html_end.upcase!
         end

--- a/lib/html/mixin/html_handler.rb
+++ b/lib/html/mixin/html_handler.rb
@@ -39,7 +39,11 @@ module HTML
       #
       def html(formatting = true)
         if self.class.respond_to?(:html_case)
-          $upper = true if self.class.html_case == 'upper'
+          if self.class.html_case == 'upper'
+            $upper = true
+          else
+            $upper = false
+          end
         end
 
         if $upper

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -10,6 +10,11 @@ require 'html/table'
 RSpec.describe HTML::Table do
   before do
     @table = described_class.new
+    @original_case = described_class.html_case
+  end
+
+  after do
+    described_class.html_case = @original_case
   end
 
   example "version" do
@@ -30,13 +35,23 @@ RSpec.describe HTML::Table do
     expect{ described_class.new(%w[foo bar baz], :border => 1) }.not_to raise_error
   end
 
-  example "html_case" do
+  example "html_case method basic functionality" do
     expect(described_class).to respond_to(:html_case)
     expect(described_class).to respond_to(:html_case=)
+  end
+
+  example "html_case writer method only accepts 'upper' and 'lower'" do
     expect{ described_class.html_case = 'upper' }.not_to raise_error
     expect{ described_class.html_case = 'lower' }.not_to raise_error
     expect{ described_class.html_case = 'foo' }.to raise_error(ArgumentError)
     expect{ described_class.html_case = 7 }.to raise_error(ArgumentTypeError)
+  end
+
+  example "html_case causes uppercased output as expected" do
+    html = '<TABLE><TR><TD>hello</TD></TR></TABLE>'
+    described_class.html_case = 'upper'
+    @table.content = 'hello'
+    expect(@table.html.gsub(/\s+/, '')).to eq(html)
   end
 
   example "indent_level" do


### PR DESCRIPTION
Currently, once the `$upper` global variable is set to true, there's no unsetting it. This modifies the current code so that it's explicitly reset to false if not set to "upper".

I've also renamed the global to make it less likely to cause a clash, and updated the specs a bit.

Ideally, this needs to be reworked to remove the global and should probably just have a single toplevel setting instead of allowing every subclass to define it. But, that's a future PR.