### PR TITLE
Convert Head and Foot to use singleton library

### DIFF
--- a/lib/html/foot.rb
+++ b/lib/html/foot.rb
@@ -1,12 +1,14 @@
+require 'singleton'
+
+# The HTML module serves as a namespace only.
 module HTML
 
-  # This class represents an HTML table foot (<tfoot>).  It is a
-  # subclass of Table::TableSection.  It is a singleton class.
+  # This class represents an HTML table foot (<tfoot>). It is a
+  # subclass of Table::TableSection. It is a singleton class.
   #
   class Table::Foot < Table::TableSection
-    private_class_method :new
+    include Singleton
 
-    @@foot        = nil
     @indent_level = 3
     @end_tags     = true
 
@@ -15,8 +17,13 @@ module HTML
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
-      @@foot = new(arg, &block) unless @@foot
-      @@foot
+      instance(arg, &block)
+    end
+
+    # Part of the singleton interface.
+    #
+    def self.instance(arg = nil, &block)
+      @instance ||= new(arg, &block)
     end
 
     # Called by create() instead of new(). This initializes the Foot class.

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -3,8 +3,8 @@ require 'singleton'
 # The HTML module serves only as a namespace.
 module HTML
 
-  # This class represents an HTML table head (<thead>).  It is a
-  # subclass of Table::TableSection.  It is a singleton class.
+  # This class represents an HTML table head (<thead>). It is a
+  # subclass of Table::TableSection. It is a singleton class.
   #
   class Table::Head < Table::TableSection
     include Singleton
@@ -17,11 +17,11 @@ module HTML
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
-      @head ||= new(arg, &block)
+      @instance ||= new(arg, &block)
     end
 
     def self.instance(arg = nil, &block)
-      @head ||= create(arg, &block)
+      create(arg, &block)
     end
 
     # Called by create() instead of new().  This initializes the Head class.

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -17,7 +17,6 @@ module HTML
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
-      @instance = nil
       instance(arg, &block)
     end
 
@@ -25,7 +24,7 @@ module HTML
       @instance ||= new(arg, &block)
     end
 
-    # Called by create() instead of new().  This initializes the Head class.
+    # Called by create() instead of new(). This initializes the Head class.
     #
     def initialize(arg, &block)
       @html_begin = '<thead'

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -20,6 +20,8 @@ module HTML
       instance(arg, &block)
     end
 
+    # Part of the singleton interface.
+    #
     def self.instance(arg = nil, &block)
       @instance ||= new(arg, &block)
     end

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -13,15 +13,16 @@ module HTML
     @end_tags     = true
 
     # This is our constructor for Head objects because it is a singleton
-    # class.  Optionally, a block may be provided.  If an argument is
+    # class. Optionally, a block may be provided. If an argument is
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
-      @instance ||= new(arg, &block)
+      @instance = nil
+      instance(arg, &block)
     end
 
     def self.instance(arg = nil, &block)
-      create(arg, &block)
+      @instance ||= new(arg, &block)
     end
 
     # Called by create() instead of new().  This initializes the Head class.

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -1,12 +1,13 @@
+require 'singleton'
+
+# The HTML module serves only as a namespace.
 module HTML
 
   # This class represents an HTML table head (<thead>).  It is a
   # subclass of Table::TableSection.  It is a singleton class.
   #
   class Table::Head < Table::TableSection
-    private_class_method :new
-
-    @@head = nil
+    include Singleton
 
     @indent_level = 3
     @end_tags     = true
@@ -16,8 +17,11 @@ module HTML
     # provided it is treated as content.
     #
     def self.create(arg = nil, &block)
-      @@head = new(arg, &block) unless @@head
-      @@head
+      @head ||= new(arg, &block)
+    end
+
+    def self.instance(arg = nil, &block)
+      @head ||= create(arg, &block)
     end
 
     # Called by create() instead of new().  This initializes the Head class.

--- a/spec/foot_spec.rb
+++ b/spec/foot_spec.rb
@@ -8,24 +8,13 @@
 require 'rspec'
 require 'html/table'
 
-class HTML::Table::Foot
-  private
-
-  def refresh
-    @@foot = nil
-  end
-end
-
 RSpec.describe HTML::Table::Foot do
   before do
-    @table = HTML::Table.new
     @tfoot = described_class.create
   end
 
   after do
-    @table = nil
-    @tfoot.send(:refresh)
-    @tfoot = nil
+    described_class.instance_variable_set(:@instance, nil)
   end
 
   example 'new_not_allowed' do
@@ -34,8 +23,17 @@ RSpec.describe HTML::Table::Foot do
 
   example 'constructor' do
     expect{ described_class.create }.not_to raise_error
+  end
+
+  example 'constructor with string' do
     expect{ described_class.create('foo') }.not_to raise_error
+  end
+
+  example 'constructor with numeric' do
     expect{ described_class.create(1) }.not_to raise_error
+  end
+
+  example 'constructor with arrays' do
     expect{ described_class.create(%w[foo bar baz]) }.not_to raise_error
     expect{ described_class.create([1, 2, 3]) }.not_to raise_error
     expect{ described_class.create([[1, 2, 3], %w[foo bar]]) }.not_to raise_error
@@ -46,31 +44,35 @@ RSpec.describe HTML::Table::Foot do
     expect(@tfoot.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'end_tags' do
+  example 'end_tags? basic functionality' do
     expect(described_class).to respond_to(:end_tags?)
-    expect(described_class).to respond_to(:end_tags=)
+    expect(described_class.end_tags?).to be(true)
     expect{ described_class.end_tags? }.not_to raise_error
+  end
+
+  example 'end_tags= basic functionality' do
+    expect(described_class).to respond_to(:end_tags=)
     expect{ described_class.end_tags = true }.not_to raise_error
   end
 
-  example 'end_tags_expected_errors' do
+  example 'end_tags raises an error on an invalid type' do
     expect{ described_class.end_tags = 'foo' }.to raise_error(HTML::Mixin::StrongTyping::ArgumentTypeError)
   end
 
-  example 'with_attributes' do
+  example 'with attributes' do
     html = "<tfoot align='left' char='x'></tfoot>"
     @tfoot.align = 'left'
     @tfoot.char = 'x'
     expect(@tfoot.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'push_single_row' do
+  example 'push single row' do
     html = '<tfoot><tr><td>test</td></tr></tfoot>'
     @tfoot.push(HTML::Table::Row.new{ |r| r.content = 'test' })
     expect(@tfoot.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'push_multiple_rows' do
+  example 'push multiple rows' do
     html = '<tfoot><tr><td>test</td></tr><tr><td>foo</td></tr></tfoot>'
     r1 = HTML::Table::Row.new{ |r| r.content = 'test' }
     r2 = HTML::Table::Row.new{ |r| r.content = 'foo' }
@@ -78,20 +80,20 @@ RSpec.describe HTML::Table::Foot do
     expect(@tfoot.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'add_content_directly' do
+  example 'add content directly' do
     html = '<tfoot><tr><td>hello</td><td>world</td></tr></tfoot>'
     @tfoot.content = 'hello', 'world'
     expect(@tfoot.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end
 
-  example 'add_content_in_constructor' do
+  example 'add content in constructor' do
     html = '<tfoot><tr><td>hello</td><td>world</td></tr></tfoot>'
-    @tfoot.send(:refresh)
+    described_class.instance_variable_set(:@instance, nil)
     @tfoot = described_class.create(%w[hello world])
     expect(@tfoot.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end
 
-  example 'configure_column' do
+  example 'configure column' do
     html = "<tfoot><tr><td>hello</td><td abbr='test' width=3 nowrap>world"
     html += '</td></tr></tfoot>'
     @tfoot.content = 'hello', 'world'
@@ -101,5 +103,13 @@ RSpec.describe HTML::Table::Foot do
       data.nowrap = true
     end
     expect(@tfoot.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
+  end
+
+  example 'singleton class' do
+    expect{ described_class.new }.to raise_error(NoMethodError)
+    expect(described_class.create).to eq(described_class.create)
+    expect(described_class.instance).to eq(described_class.instance)
+    expect(described_class.instance.object_id).to eq(described_class.instance.object_id)
+    expect(described_class.create.object_id).to eq(described_class.create.object_id)
   end
 end

--- a/spec/head_spec.rb
+++ b/spec/head_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe HTML::Table::Head do
 
   example 'add content in constructor' do
     html = '<thead><tr><td>hello</td><td>world</td></tr></thead>'
+    described_class.instance_variable_set(:@instance, nil)
     @thead = described_class.create(%w[hello world])
     expect(@thead.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end

--- a/spec/head_spec.rb
+++ b/spec/head_spec.rb
@@ -54,20 +54,20 @@ RSpec.describe HTML::Table::Head do
     expect{ described_class.end_tags = 'foo' }.to raise_error(HTML::Mixin::StrongTyping::ArgumentTypeError)
   end
 
-  example 'with_attributes' do
+  example 'with attributes' do
     html = "<thead align='left' char='x'></thead>"
     @thead.align = 'left'
     @thead.char = 'x'
     expect(@thead.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'push_single_row' do
+  example 'push single row' do
     html = '<thead><tr><td>test</td></tr></thead>'
     @thead.push(HTML::Table::Row.new{ |r| r.content = 'test' })
     expect(@thead.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'push_multiple_rows' do
+  example 'push multiple rows' do
     html = '<thead><tr><td>test</td></tr><tr><td>foo</td></tr></thead>'
     r1 = HTML::Table::Row.new('test')
     r2 = HTML::Table::Row.new('foo')
@@ -75,19 +75,19 @@ RSpec.describe HTML::Table::Head do
     expect(@thead.html.gsub(/\s{2,}|\n/, '')).to eq(html)
   end
 
-  example 'add_content_directly' do
+  example 'add content directly' do
     html = '<thead><tr><td>hello</td><td>world</td></tr></thead>'
     @thead.content = 'hello', 'world'
     expect(@thead.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end
 
-  example 'add_content_in_constructor' do
+  example 'add content in constructor' do
     html = '<thead><tr><td>hello</td><td>world</td></tr></thead>'
     @thead = described_class.create(%w[hello world])
     expect(@thead.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end
 
-  example 'configure_column' do
+  example 'configure column' do
     html = "<thead><tr><td>hello</td><td abbr='test' width=3 nowrap>world"
     html += '</td></tr></thead>'
     @thead.content = 'hello', 'world'

--- a/spec/head_spec.rb
+++ b/spec/head_spec.rb
@@ -43,12 +43,15 @@ RSpec.describe HTML::Table::Head do
   example 'end_tags? basic functionality' do
     expect(described_class).to respond_to(:end_tags?)
     expect(described_class.end_tags?).to be(true)
+    expect{ described_class.end_tags? }.not_to raise_error
+  end
+
+  example 'end_tags= basic functionality' do
+    expect(described_class).to respond_to(:end_tags=)
+    expect{ described_class.end_tags = true }.not_to raise_error
   end
 
   example 'end_tags= does not allow invalid types' do
-    expect(described_class).to respond_to(:end_tags=)
-    expect{ described_class.end_tags? }.not_to raise_error
-    expect{ described_class.end_tags = true }.not_to raise_error
     expect{ described_class.end_tags = 'foo' }.to raise_error(HTML::Mixin::StrongTyping::ArgumentTypeError)
   end
 

--- a/spec/head_spec.rb
+++ b/spec/head_spec.rb
@@ -8,18 +8,6 @@
 require 'rspec'
 require 'html/table'
 
-#####################################################################
-# Ensure that a fresh instance of described_class is used between tests
-# by calling 'refresh' in the 'teardown' method.
-#####################################################################
-class HTML::Table::Head
-  private
-
-  def refresh
-    @@head = nil
-  end
-end
-
 RSpec.describe HTML::Table::Head do
   before do
     @table = HTML::Table.new
@@ -28,7 +16,6 @@ RSpec.describe HTML::Table::Head do
 
   after do
     @table = nil
-    @thead.send(:refresh)
     @thead = nil
   end
 
@@ -96,7 +83,6 @@ RSpec.describe HTML::Table::Head do
 
   example 'add_content_in_constructor' do
     html = '<thead><tr><td>hello</td><td>world</td></tr></thead>'
-    @thead.send(:refresh)
     @thead = described_class.create(%w[hello world])
     expect(@thead.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end

--- a/spec/head_spec.rb
+++ b/spec/head_spec.rb
@@ -10,13 +10,11 @@ require 'html/table'
 
 RSpec.describe HTML::Table::Head do
   before do
-    @table = HTML::Table.new
     @thead = described_class.create
   end
 
   after do
-    @table = nil
-    @thead = nil
+    described_class.instance_variable_set(:@instance, nil)
   end
 
   example 'constructor' do
@@ -97,5 +95,13 @@ RSpec.describe HTML::Table::Head do
       d.nowrap = true
     end
     expect(@thead.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
+  end
+
+  example 'singleton class' do
+    expect{ described_class.new }.to raise_error(NoMethodError)
+    expect(described_class.create).to eq(described_class.create)
+    expect(described_class.instance).to eq(described_class.instance)
+    expect(described_class.instance.object_id).to eq(described_class.instance.object_id)
+    expect(described_class.create.object_id).to eq(described_class.create.object_id)
   end
 end


### PR DESCRIPTION
We previously had a hand-rolled singleton implementation that used class variables, which is ugly. I updated the Head and Foot class to use Ruby's own singleton library instead, and updated the specs.