### PR TITLE
Strongtyping include refactor

### DIFF
--- a/lib/html/body.rb
+++ b/lib/html/body.rb
@@ -1,9 +1,11 @@
+# The HTML module serves as a namespace only.
 module HTML
-
   # This class represents an HTML table body (<tbody>).  It is a
   # subclass of Table::TableSection.
   #
   class Table::Body < Table::TableSection
+    extend HTML::Mixin::StrongTyping
+
     @indent_level = 3
     @end_tags     = true
 

--- a/lib/html/caption.rb
+++ b/lib/html/caption.rb
@@ -1,3 +1,4 @@
+# The HTML module serves as a namespace only.
 module HTML
 
   # This class represents an HTML Caption.  Despite the name, it is not
@@ -6,6 +7,7 @@ module HTML
   class Table::Caption
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    extend HTML::Mixin::StrongTyping
 
     undef_method :configure
     @indent_level = 3

--- a/lib/html/col.rb
+++ b/lib/html/col.rb
@@ -1,10 +1,13 @@
+# The HTML module serves as a namespace only.
 module HTML
+
   # This class represents an HTML ColGroup column (<col>).  Despite the
   # name, it is not a subclass of ColGroup or Table.
   #
   class Table::ColGroup::Col
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    extend HTML::Mixin::StrongTyping
 
     undef_method :configure, :content
     @indent_level = 6

--- a/lib/html/colgroup.rb
+++ b/lib/html/colgroup.rb
@@ -1,4 +1,6 @@
+# The HTML module serves as a namespace only.
 module HTML
+
   # This class represents an HTML column group (<colgroup>).  It is a
   # subclass of Array.  The only elements it may contain are instances
   # of the ColGroup::Col class.
@@ -6,6 +8,8 @@ module HTML
   class Table::ColGroup < Array
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    include HTML::Mixin::StrongTyping
+    extend HTML::Mixin::StrongTyping
 
     @indent_level = 3
     @end_tags     = true

--- a/lib/html/data.rb
+++ b/lib/html/data.rb
@@ -1,3 +1,4 @@
+# The HTML module serves as a namespace only.
 module HTML
 
   # This class represents HTML table data, <td>.  Despite the name
@@ -6,6 +7,7 @@ module HTML
   class Table::Row::Data
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    extend HTML::Mixin::StrongTyping
 
     undef_method :configure
 

--- a/lib/html/foot.rb
+++ b/lib/html/foot.rb
@@ -8,6 +8,7 @@ module HTML
   #
   class Table::Foot < Table::TableSection
     include Singleton
+    extend HTML::Mixin::StrongTyping
 
     @indent_level = 3
     @end_tags     = true

--- a/lib/html/head.rb
+++ b/lib/html/head.rb
@@ -8,6 +8,7 @@ module HTML
   #
   class Table::Head < Table::TableSection
     include Singleton
+    extend HTML::Mixin::StrongTyping
 
     @indent_level = 3
     @end_tags     = true

--- a/lib/html/header.rb
+++ b/lib/html/header.rb
@@ -1,3 +1,4 @@
+# The HTML module serves as a namespace only.
 module HTML
 
   # This class represents an HTML table header (<th>).  Despite the name
@@ -6,6 +7,7 @@ module HTML
   class Table::Row::Header
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    extend HTML::Mixin::StrongTyping
 
     undef_method :configure
 

--- a/lib/html/mixin/strongtyping.rb
+++ b/lib/html/mixin/strongtyping.rb
@@ -4,13 +4,12 @@ module HTML
   module Mixin
     # The StrongTyping module is a pure Ruby replacement for the strongtyping gem.
     module StrongTyping
-      class ArgumentTypeError < ArgumentError; end
-
       def expect(arg, allowed_types)
         return true if Array(allowed_types).any? do |klass|
           arg.is_a?(klass)
         end
 
+        # Defined in table.rb
         raise ArgumentTypeError, "#{arg} must be of type #{allowed_types}"
       end
     end

--- a/lib/html/row.rb
+++ b/lib/html/row.rb
@@ -1,10 +1,13 @@
 # The HTML module is a namespace only.
 module HTML
+
   # The Table::Row class is a subclass of array that encapsulates an
   # html table row, i.e. <tr> element.
   class Table::Row < Array
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    include HTML::Mixin::StrongTyping
+    extend HTML::Mixin::StrongTyping
 
     @indent_level = 3
     @end_tags     = true

--- a/lib/html/table.rb
+++ b/lib/html/table.rb
@@ -9,6 +9,9 @@ class NonStandardExtensionWarning < StructuredWarnings::StandardWarning; end
 # Please, think of the children before using the blink tag.
 class BlinkWarning < StructuredWarnings::StandardWarning; end
 
+# Used by the strongtyping mixin.
+class ArgumentTypeError < ArgumentError; end
+
 # The HTML module serves as a namespace only.
 module HTML
 

--- a/lib/html/table.rb
+++ b/lib/html/table.rb
@@ -2,7 +2,6 @@ require_relative 'mixin/attribute_handler'
 require_relative 'mixin/html_handler'
 require_relative 'mixin/strongtyping'
 require 'structured_warnings'
-include HTML::Mixin::StrongTyping
 
 # Warning raised if a non-standard extension is used.
 class NonStandardExtensionWarning < StructuredWarnings::StandardWarning; end
@@ -18,6 +17,8 @@ module HTML
   class Table < Array
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    include HTML::Mixin::StrongTyping
+    extend HTML::Mixin::StrongTyping
 
     # The version of the html-table library
     VERSION = '1.7.0'.freeze

--- a/lib/html/tablesection.rb
+++ b/lib/html/tablesection.rb
@@ -1,9 +1,13 @@
+# The HTML module serves as a namespace only.
 module HTML
+
   # Superclass for THEAD, TBODY, TFOOT
   #
   class Table::TableSection < Array
     include HTML::Mixin::AttributeHandler
     include HTML::Mixin::HtmlHandler
+    include HTML::Mixin::StrongTyping
+    extend HTML::Mixin::StrongTyping
 
     def initialize(&block)
       super

--- a/spec/foot_spec.rb
+++ b/spec/foot_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe HTML::Table::Foot do
   end
 
   example 'end_tags raises an error on an invalid type' do
-    expect{ described_class.end_tags = 'foo' }.to raise_error(HTML::Mixin::StrongTyping::ArgumentTypeError)
+    expect{ described_class.end_tags = 'foo' }.to raise_error(ArgumentTypeError)
   end
 
   example 'with attributes' do

--- a/spec/head_spec.rb
+++ b/spec/head_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe HTML::Table::Head do
   end
 
   example 'end_tags= does not allow invalid types' do
-    expect{ described_class.end_tags = 'foo' }.to raise_error(HTML::Mixin::StrongTyping::ArgumentTypeError)
+    expect{ described_class.end_tags = 'foo' }.to raise_error(ArgumentTypeError)
   end
 
   example 'with attributes' do


### PR DESCRIPTION
Instead of including the Strongtyping module globally, only include it in the classes that actually use it.