### PR TITLE
Remove global variable

### DIFF
--- a/lib/html/mixin/html_handler.rb
+++ b/lib/html/mixin/html_handler.rb
@@ -4,9 +4,6 @@ module HTML
   module Mixin
     # The HtmlHandler module is the library for generating html output.
     module HtmlHandler
-
-      $html_table_uppercase = false
-
       # Used on HTML attributes. It creates proper HTML text based on the argument
       # type. A string looks like "attr='text'", a number looks like "attr=1",
       # while a true value simply looks like "attr" (no equal sign).
@@ -43,15 +40,7 @@ module HTML
       # honored.
       #
       def html(formatting = true)
-        if self.class.respond_to?(:html_case)
-          if self.class.html_case == 'upper'
-            $html_table_uppercase = true
-          else
-            $html_table_uppercase = false
-          end
-        end
-
-        if $html_table_uppercase
+        if HTML::Table.html_case == 'upper'
           @html_begin.upcase!
           @html_end.upcase!
         end

--- a/lib/html/table.rb
+++ b/lib/html/table.rb
@@ -164,7 +164,7 @@ module HTML
       @html_case
     end
 
-    # Sets the case of all HTML tags to either lower or upper.  The only
+    # Sets the case of all HTML tags to either lower or upper. The only
     # valid arguments to this method are 'upper' or 'lower'.
     #
     def self.html_case=(arg)


### PR DESCRIPTION
Get rid of the global variable.

Apparently I originally allowed for individual elements to be capitalized for some reason. Getting rid of the global and just checking for the `HTML::Table.html_case` setting lets me kill two birds with one stone.