### PR TITLE
Refactoring Colgroup

### DIFF
--- a/lib/html/colgroup.rb
+++ b/lib/html/colgroup.rb
@@ -63,11 +63,7 @@ module HTML
     #
     def push(*args)
       args.each do |obj|
-        unless obj.is_a?(Table::ColGroup::Col)
-          msg = 'Can only assign Col objects to ColGroup class'
-          msg += ": #{obj.class}"
-          raise TypeError, msg
-        end
+        expect(obj, Table::ColGroup::Col)
         super(obj)
       end
     end

--- a/lib/html/colgroup.rb
+++ b/lib/html/colgroup.rb
@@ -76,11 +76,7 @@ module HTML
     # to be pushed onto a ColGroup instance.
     #
     def <<(obj)
-      unless obj.is_a?(Table::ColGroup::Col)
-        msg = 'Can only assign Col objects to ColGroup class'
-        msg += ": #{obj.class}"
-        raise TypeError, msg
-      end
+      expect(obj, Table::ColGroup::Col)
       super
     end
 

--- a/lib/html/colgroup.rb
+++ b/lib/html/colgroup.rb
@@ -84,10 +84,7 @@ module HTML
     # to be unshifted onto a ColGroup instance.
     #
     def unshift(obj)
-      unless obj.is_a?(Table::ColGroup::Col)
-        msg = 'Can only assign Data and Header objects to Row class'
-        raise TypeError, msg
-      end
+      expect(obj, Table::ColGroup::Col)
       super
     end
 

--- a/spec/colgroup_spec.rb
+++ b/spec/colgroup_spec.rb
@@ -23,45 +23,52 @@ RSpec.describe HTML::Table::ColGroup do
     expect(@cgroup.html.gsub(/\s+/, '')).to eq(html)
   end
 
-  example 'with_attributes' do
+  example 'with attributes' do
     html = "<colgroup align='center' width='20%'></colgroup>"
     @cgroup.align = 'center'
     @cgroup.width = '20%'
     expect(@cgroup.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end
 
-  example 'push_single_col_element' do
+  example 'push single col element' do
     html = '<colgroup><col></colgroup>'
     @cgroup.push(@col)
     expect(@cgroup.html.gsub(/\s{2,}|\n+/, '')).to eq(html)
   end
 
-  example 'index_assignment_constraints' do
+  example 'index assignment constraints' do
     expect{ @cgroup[0] = 'foo' }.to raise_error(ArgumentTypeError)
     expect{ @cgroup[0] = 1 }.to raise_error(ArgumentTypeError)
     expect{ @cgroup[1] = HTML::Table::Row.new }.to raise_error(ArgumentTypeError)
     expect{ @cgroup[0] = HTML::Table::ColGroup::Col.new }.not_to raise_error
   end
 
-  example 'push_constraints' do
+  example 'push constraints' do
     expect{ @cgroup.push(7) }.to raise_error(TypeError)
     expect{ @cgroup.push('hello') }.to raise_error(TypeError)
     expect{ @cgroup.push(HTML::Table::Row.new) }.to raise_error(TypeError)
     expect{ @cgroup.push(HTML::Table::ColGroup::Col.new) }.not_to raise_error
   end
 
-  example 'double_arrow_constraints' do
+  example 'double arrow constraints' do
     expect{ @cgroup << 7 }.to raise_error(ArgumentTypeError)
     expect{ @cgroup << 'hello' }.to raise_error(ArgumentTypeError)
     expect{ @cgroup << HTML::Table::Row.new }.to raise_error(ArgumentTypeError)
     expect{ @cgroup << HTML::Table::ColGroup::Col.new }.not_to raise_error
   end
 
-  example 'configure_error' do
+  example 'unshift constraints' do
+    expect{ @cgroup.unshift(7) }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup.unshift('hello') }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup.unshift(HTML::Table::Row.new) }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup.unshift(HTML::Table::ColGroup::Col.new) }.not_to raise_error
+  end
+
+  example 'configure error' do
     expect{ @cgroup.configure(0, 0){} }.to raise_error(ArgumentError)
   end
 
-  example 'content_error' do
+  example 'content error' do
     expect{ @cgroup.content }.to raise_error(NoMethodError)
     expect{ @cgroup.content = 'blah' }.to raise_error(NoMethodError)
   end

--- a/spec/colgroup_spec.rb
+++ b/spec/colgroup_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe HTML::Table::ColGroup do
   example 'constructor' do
     expect{ described_class.new }.not_to raise_error
     expect{ described_class.new(@col) }.not_to raise_error
-    expect{ described_class.new('foo') }.to raise_error(TypeError)
+    expect{ described_class.new('foo') }.to raise_error(ArgumentTypeError)
   end
 
   example 'basic' do
@@ -44,9 +44,9 @@ RSpec.describe HTML::Table::ColGroup do
   end
 
   example 'push constraints' do
-    expect{ @cgroup.push(7) }.to raise_error(TypeError)
-    expect{ @cgroup.push('hello') }.to raise_error(TypeError)
-    expect{ @cgroup.push(HTML::Table::Row.new) }.to raise_error(TypeError)
+    expect{ @cgroup.push(7) }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup.push('hello') }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup.push(HTML::Table::Row.new) }.to raise_error(ArgumentTypeError)
     expect{ @cgroup.push(HTML::Table::ColGroup::Col.new) }.not_to raise_error
   end
 

--- a/spec/colgroup_spec.rb
+++ b/spec/colgroup_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe HTML::Table::ColGroup do
   end
 
   example 'double_arrow_constraints' do
-    expect{ @cgroup << 7 }.to raise_error(TypeError)
-    expect{ @cgroup << 'hello' }.to raise_error(TypeError)
-    expect{ @cgroup << HTML::Table::Row.new }.to raise_error(TypeError)
+    expect{ @cgroup << 7 }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup << 'hello' }.to raise_error(ArgumentTypeError)
+    expect{ @cgroup << HTML::Table::Row.new }.to raise_error(ArgumentTypeError)
     expect{ @cgroup << HTML::Table::ColGroup::Col.new }.not_to raise_error
   end
 


### PR DESCRIPTION
Replaces a bunch of manual type checks with `expect` which we use just about everywhere else. In one case the error message was wrong.

I also added some unshift specs.